### PR TITLE
feat: claim for winners from cli

### DIFF
--- a/cli/src/entrypoint.rs
+++ b/cli/src/entrypoint.rs
@@ -70,6 +70,10 @@ pub enum Command {
         raffle: Pubkey,
         creator_proceeds: Pubkey,
     },
+    // Claim for winners
+    ClaimForWinners {
+        raffle: Pubkey,
+    },
     // Close entrants
     CloseEntrants {
         raffle: Pubkey,
@@ -147,6 +151,7 @@ pub fn entry(opts: Opts) -> Result<()> {
             creator_proceeds,
             &payer2,
         ),
+        Command::ClaimForWinners { raffle } => claim_for_winners(&program_client, raffle),
         Command::CloseEntrants { raffle } => close_entrants(&program_client, raffle),
     }
 }

--- a/cli/src/entrypoint.rs
+++ b/cli/src/entrypoint.rs
@@ -1,21 +1,26 @@
 use anchor_client::anchor_lang::Key;
 use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
-use anchor_client::solana_sdk::signature::Signer;
-use anchor_client::solana_sdk::{
-    commitment_config::CommitmentConfig,
-    instruction::Instruction,
-    signature::{read_keypair_file, Keypair},
-    system_instruction, system_program, sysvar,
-    transaction::Transaction,
+use anchor_client::solana_sdk::program_pack::Pack;
+use anchor_client::{
+    solana_sdk::{
+        commitment_config::CommitmentConfig,
+        instruction::Instruction,
+        signature::Signer,
+        signature::{read_keypair_file, Keypair},
+        system_instruction, system_program, sysvar,
+        transaction::Transaction,
+    },
+    Client, Cluster,
 };
-use anchor_client::{Client, Cluster};
 use anchor_lang::prelude::*;
 use anchor_lang::InstructionData;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bincode::deserialize;
 use chrono::NaiveDateTime;
 use clap::Parser;
+use draffle::Entrants;
 use spl_associated_token_account;
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -349,6 +354,107 @@ fn collect_proceeds(
     )?;
 
     Ok(())
+}
+
+/// If the winners haven't claimed it is permissionless to claim into their wallet
+fn claim_for_winners(program_client: &anchor_client::Program, raffle: Pubkey) -> Result<()> {
+    let raffle_state: draffle::Raffle = program_client.account(raffle)?;
+
+    let randomness = raffle_state.randomness
+        .context("The randomness has not been revealed yet, raffle could still be ongoing or reveal_winners needs to be called")?;
+
+    let entrants_account_data = program_client
+        .rpc()
+        .get_account_data(&raffle_state.entrants)
+        .expect("Entrants not found for the raffle, is it already closed?");
+    let entrants: draffle::Entrants = program_client.account(raffle_state.entrants)?;
+    for prize_index in 0..raffle_state.total_prizes {
+        let ticket_index =
+            draffle::randomness_tools::expand(randomness, prize_index) & entrants.total;
+        println!("prize {}, winning ticket {}", prize_index, ticket_index);
+
+        let winner = Entrants::get_entrant(
+            RefCell::new(&mut entrants_account_data.clone()[..]).borrow(),
+            ticket_index as usize,
+        );
+
+        let prize = Pubkey::find_program_address(
+            &[raffle.as_ref(), b"prize", &prize_index.to_le_bytes()],
+            &program_client.id(),
+        )
+        .0;
+
+        let prize_token_account = spl_token::state::Account::unpack(
+            &program_client
+                .rpc()
+                .get_account_data(&prize)
+                .expect("Prize account does not exist, but it should be unreachable"),
+        )?;
+
+        if prize_token_account.amount == 0 {
+            println!(
+                "Skipping prize {} as it has already been claimed",
+                prize_index
+            );
+            continue;
+        }
+
+        let winner_token_account = spl_associated_token_account::get_associated_token_address(
+            &winner,
+            &prize_token_account.mint,
+        );
+
+        program_client
+            .request()
+            .instruction(
+                build_associated_token_account_create_idempotent_instruction(
+                    &program_client.payer(),
+                    &winner,
+                    &prize_token_account.mint,
+                    &spl_token::ID,
+                ),
+            )
+            .accounts(draffle::accounts::ClaimPrize {
+                raffle,
+                entrants: raffle_state.entrants,
+                prize,
+                winner_token_account,
+                token_program: spl_token::ID,
+            })
+            .args(draffle::instruction::ClaimPrize {
+                prize_index,
+                ticket_index,
+            })
+            .send()?;
+    }
+
+    Ok(())
+}
+
+// Copy/pasted as 1.1.0 isn't released yet and we want CreateIdempotent
+fn build_associated_token_account_create_idempotent_instruction(
+    funding_address: &Pubkey,
+    wallet_address: &Pubkey,
+    token_mint_address: &Pubkey,
+    token_program_id: &Pubkey,
+) -> Instruction {
+    let associated_account_address = spl_associated_token_account::get_associated_token_address(
+        wallet_address,
+        token_mint_address,
+    );
+
+    Instruction {
+        program_id: spl_associated_token_account::ID,
+        accounts: vec![
+            AccountMeta::new(*funding_address, true),
+            AccountMeta::new(associated_account_address, false),
+            AccountMeta::new_readonly(*wallet_address, false),
+            AccountMeta::new_readonly(*token_mint_address, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+            AccountMeta::new_readonly(*token_program_id, false),
+        ],
+        data: vec![1],
+    }
 }
 
 fn close_entrants(program_client: &anchor_client::Program, raffle: Pubkey) -> Result<()> {

--- a/cli/src/entrypoint.rs
+++ b/cli/src/entrypoint.rs
@@ -375,7 +375,7 @@ fn claim_for_winners(program_client: &anchor_client::Program, raffle: Pubkey) ->
     let entrants: draffle::Entrants = program_client.account(raffle_state.entrants)?;
     for prize_index in 0..raffle_state.total_prizes {
         let ticket_index =
-            draffle::randomness_tools::expand(randomness, prize_index) & entrants.total;
+            draffle::randomness_tools::expand(randomness, prize_index) % entrants.total;
         println!("prize {}, winning ticket {}", prize_index, ticket_index);
 
         let winner = Entrants::get_entrant(


### PR DESCRIPTION
As requested on discord, a few people have raffle entrants account with winners who never claimed, this allow claiming into the winner token accounts.